### PR TITLE
Rename the url of the authors to members

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -67,6 +67,7 @@ outputs:
 
 # Permalinks
 permalinks:
+  authors: "/members/:slug/"
   event: "/events/:slug/"
   post: "/posts/:slug/"
   project: "/projects/:slug/"

--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -1,0 +1,6 @@
+---
+# Disable the list page of the authors taxonomy.
+_build:
+  render: never
+  list: never
+---


### PR DESCRIPTION
This changes the permalink of the authors taxonomy and disables the list
page of the authors content type.