### PR TITLE
Comment on where the research line menu entries are defined

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -26,6 +26,7 @@ main:
   - name: Research Lines
     url: "/research-lines"
     weight: 25
+    # The individual research line entries are added in the front matter of those content pages
   - name: Research
     weight: 30
     hasChildren: true


### PR DESCRIPTION
All menu entries are defined in the menu config except for the dynamic
research line entries. Therefore, I added a comment indicated where
these entries can be found.